### PR TITLE
Add mentor application link to mentor button

### DIFF
--- a/apps/site/src/components/BookmarkLink/BookmarkLink.tsx
+++ b/apps/site/src/components/BookmarkLink/BookmarkLink.tsx
@@ -6,11 +6,13 @@ import styles from "./BookmarkLink.module.scss";
 interface BookmarkLinkProps {
 	className?: string;
 	href: string;
+	target?: string;
 }
 
 export default function BookmarkLink({
 	className,
 	href,
+	target,
 	children,
 }: PropsWithChildren<BookmarkLinkProps>) {
 	return (
@@ -18,6 +20,7 @@ export default function BookmarkLink({
 			className={styles.bookmarkLink + " " + className}
 			variant=""
 			href={href}
+			target={target}
 		>
 			{children}
 		</Button>

--- a/apps/site/src/views/Home/sections/Mentor/Mentor.tsx
+++ b/apps/site/src/views/Home/sections/Mentor/Mentor.tsx
@@ -9,7 +9,7 @@ import tape from "@/assets/images/tape.svg";
 
 import styles from "./Mentor.module.scss";
 
-const MENTOR_APP_URL = "https://hack.ics.uci.edu";
+const MENTOR_APP_URL = "/mentor";
 
 export default function Mentor() {
 	const mentorHeader = (
@@ -23,7 +23,7 @@ export default function Mentor() {
 		</p>
 	);
 	const applyLink = (
-		<BookmarkLink className="mb-4" href={MENTOR_APP_URL}>
+		<BookmarkLink className="mb-4" href={MENTOR_APP_URL} target="_blank">
 			Apply to Mentor!
 		</BookmarkLink>
 	);


### PR DESCRIPTION
Redoing #39
- `/mentor` redirect already included in 03cd11f
- Include `target` prop on `BookmarkLink`