### PR TITLE
Add 2023 to metadata title

### DIFF
--- a/apps/site/src/app/layout.tsx
+++ b/apps/site/src/app/layout.tsx
@@ -7,7 +7,7 @@ import "@/lib/styles/bootstrap.scss";
 import "@/lib/styles/globals.scss";
 
 export const metadata: Metadata = {
-	title: "ZotHacks",
+	title: "ZotHacks 2023",
 	description: "Hack at UCI's premier hackathon for beginners at UCI",
 };
 


### PR DESCRIPTION
Currently, the metadata title in the tab only shows "ZotHacks" instead of "ZotHacks 2023".