### PR TITLE
update: remove apply links and mentor section

### DIFF
--- a/apps/site/src/components/BookmarkLink/BookmarkLink.module.scss
+++ b/apps/site/src/components/BookmarkLink/BookmarkLink.module.scss
@@ -16,7 +16,7 @@
 	--bs-btn-active-shadow: none;
 	--bs-btn-border-radius: 0;
 
-	padding-left: 1.5rem;
+	padding-left: 0.75rem;
 	padding-right: 0;
 
 	filter: drop-shadow(2px 1px 4px rgba(black, 0.15));

--- a/apps/site/src/components/BookmarkLink/BookmarkLink.tsx
+++ b/apps/site/src/components/BookmarkLink/BookmarkLink.tsx
@@ -6,6 +6,7 @@ import styles from "./BookmarkLink.module.scss";
 interface BookmarkLinkProps {
 	className?: string;
 	href: string;
+	disabled?: boolean;
 	target?: string;
 }
 
@@ -13,6 +14,7 @@ export default function BookmarkLink({
 	className,
 	href,
 	target,
+	disabled = false,
 	children,
 }: PropsWithChildren<BookmarkLinkProps>) {
 	return (
@@ -21,6 +23,7 @@ export default function BookmarkLink({
 			variant=""
 			href={href}
 			target={target}
+			disabled={disabled}
 		>
 			{children}
 		</Button>

--- a/apps/site/src/views/Home/Home.tsx
+++ b/apps/site/src/views/Home/Home.tsx
@@ -1,5 +1,6 @@
 import Landing from "./sections/Landing/Landing";
 import Intro from "./sections/Intro/Intro";
+import Mentor from "./sections/Mentor/Mentor";
 import FAQ from "./sections/FAQ/FAQ";
 
 import StickerLayout from "./components/StickerLayout/StickerLayout";
@@ -9,10 +10,11 @@ import styles from "./Home.module.scss";
 function Home() {
 	return (
 		<>
+			<StickerLayout />
 			<div className={styles.home}>
 				<Landing />
 				<Intro />
-				{/* <Mentor /> */}
+				<Mentor />
 				<FAQ />
 			</div>
 		</>

--- a/apps/site/src/views/Home/Home.tsx
+++ b/apps/site/src/views/Home/Home.tsx
@@ -1,7 +1,5 @@
 import Landing from "./sections/Landing/Landing";
 import Intro from "./sections/Intro/Intro";
-import Mentor from "./sections/Mentor/Mentor";
-import Sponsors from "./sections/Sponsors/Sponsors";
 import FAQ from "./sections/FAQ/FAQ";
 
 import StickerLayout from "./components/StickerLayout/StickerLayout";
@@ -11,11 +9,10 @@ import styles from "./Home.module.scss";
 function Home() {
 	return (
 		<>
-			<StickerLayout />
 			<div className={styles.home}>
 				<Landing />
 				<Intro />
-				<Mentor />
+				{/* <Mentor /> */}
 				<FAQ />
 			</div>
 		</>

--- a/apps/site/src/views/Home/components/ApplyButton/ApplyButton.module.scss
+++ b/apps/site/src/views/Home/components/ApplyButton/ApplyButton.module.scss
@@ -11,12 +11,12 @@ $skew-amount: -30deg;
 		$hover-border: theme.$black,
 		$active-border: theme.$black
 	);
-	@include bootstrap.rfs(6rem, --bs-btn-padding-x);
 	--bs-btn-font-weight: bold;
 	--bs-btn-border-width: 4px;
 
-	@include bootstrap.font-size(bootstrap.$h2-font-size);
+	@include bootstrap.font-size(bootstrap.$h4-font-size);
 
+	max-width: 70%;
 	transform: skew($skew-amount);
 	// unskew children
 	> * {

--- a/apps/site/src/views/Home/components/ApplyButton/ApplyButton.tsx
+++ b/apps/site/src/views/Home/components/ApplyButton/ApplyButton.tsx
@@ -9,8 +9,9 @@ export default function ApplyButton() {
 			href="/apply"
 			variant=""
 			target="_blank"
+			disabled
 		>
-			<div>Apply</div>
+			<div>Applications have closed!</div>
 		</Button>
 	);
 }

--- a/apps/site/src/views/Home/components/StickerLayout/StickerLayout.tsx
+++ b/apps/site/src/views/Home/components/StickerLayout/StickerLayout.tsx
@@ -1,3 +1,16 @@
+import { HeartSticker } from "@/components/Sticker/Stickers";
+
 export default function StickerLayout() {
-	return <></>;
+	return (
+		<>
+			<HeartSticker
+				style={{
+					position: "absolute",
+					top: "55%",
+					right: "20%",
+					zIndex: 100,
+				}}
+			/>
+		</>
+	);
 }

--- a/apps/site/src/views/Home/components/StickerLayout/StickerLayout.tsx
+++ b/apps/site/src/views/Home/components/StickerLayout/StickerLayout.tsx
@@ -1,14 +1,3 @@
-import { HackSticker, HeartSticker } from "@/components/Sticker/Stickers";
-
 export default function StickerLayout() {
-	return (
-		<HeartSticker
-			style={{
-				position: "absolute",
-				top: "43%",
-				left: "55%",
-				zIndex: 100,
-			}}
-		/>
-	);
+	return <></>;
 }

--- a/apps/site/src/views/Home/sections/Landing/Landing.module.scss
+++ b/apps/site/src/views/Home/sections/Landing/Landing.module.scss
@@ -1,5 +1,5 @@
 .landing {
-	min-height: 62vh;
+	min-height: 70vh;
 
 	display: flex;
 	flex-direction: column;

--- a/apps/site/src/views/Home/sections/Landing/Landing.tsx
+++ b/apps/site/src/views/Home/sections/Landing/Landing.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import ApplyButton from "@/views/Home/components/ApplyButton/ApplyButton";
+import { HeartSticker } from "@/components/Sticker/Stickers";
 
 import styles from "./Landing.module.scss";
 
@@ -9,7 +9,8 @@ function Landing() {
 		<div className={styles.landing}>
 			<h1>ZotHacks 2023</h1>
 			<p className="fs-2">November 4&ndash;5</p>
-			<ApplyButton />
+			<HeartSticker />
+			{/* <ApplyButton /> */}
 		</div>
 	);
 }

--- a/apps/site/src/views/Home/sections/Landing/Landing.tsx
+++ b/apps/site/src/views/Home/sections/Landing/Landing.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { HeartSticker } from "@/components/Sticker/Stickers";
+import ApplyButton from "../../components/ApplyButton/ApplyButton";
 
 import styles from "./Landing.module.scss";
 
@@ -9,8 +9,7 @@ function Landing() {
 		<div className={styles.landing}>
 			<h1>ZotHacks 2023</h1>
 			<p className="fs-2">November 4&ndash;5</p>
-			<HeartSticker />
-			{/* <ApplyButton /> */}
+			<ApplyButton />
 		</div>
 	);
 }

--- a/apps/site/src/views/Home/sections/Mentor/Mentor.tsx
+++ b/apps/site/src/views/Home/sections/Mentor/Mentor.tsx
@@ -18,14 +18,9 @@ export default function Mentor() {
 	const mentorDescription = (
 		<p>
 			Have a knack for innovation? Interested in inspiring the next generation
-			of developers? Our mentors are vital to making ZotHacks 2023 successful
-			and enjoyable for our hackers. Apply to be a mentor today!
+			of developers? Mentor applications for ZotHacks 2023 have closed, but
+			please keep an eye out for future events!
 		</p>
-	);
-	const applyLink = (
-		<BookmarkLink className="mb-4" href={MENTOR_APP_URL} target="_blank">
-			Apply to Mentor!
-		</BookmarkLink>
 	);
 
 	return (
@@ -37,11 +32,9 @@ export default function Mentor() {
 						{mentorHeader}
 						{mentorDescription}
 					</div>
-					{applyLink}
 				</Col>
 				<Col className={styles.descSticky + " text-center"}>
 					{mentorDescription}
-					{applyLink}
 				</Col>
 			</div>
 		</Container>

--- a/apps/site/src/views/Home/sections/Mentor/Mentor.tsx
+++ b/apps/site/src/views/Home/sections/Mentor/Mentor.tsx
@@ -22,6 +22,16 @@ export default function Mentor() {
 			please keep an eye out for future events!
 		</p>
 	);
+	const applyLink = (
+		<BookmarkLink
+			className="mb-4"
+			href={MENTOR_APP_URL}
+			target="_blank"
+			disabled
+		>
+			Applications have closed.
+		</BookmarkLink>
+	);
 
 	return (
 		<Container as="section">
@@ -32,9 +42,11 @@ export default function Mentor() {
 						{mentorHeader}
 						{mentorDescription}
 					</div>
+					{applyLink}
 				</Col>
 				<Col className={styles.descSticky + " text-center"}>
 					{mentorDescription}
+					{applyLink}
 				</Col>
 			</div>
 		</Container>


### PR DESCRIPTION
Now that applications have closed, I removed the apply button and the mentor section (both via comments) and shifted the heart sticker so now it lies right beneath the dates. This should also resolve any lingering issues with horizontal overflow on mobile views caused by the sticker.