### PR TITLE
feat: add day of week to schedule

### DIFF
--- a/apps/site/src/views/Schedule/sections/ClipboardSchedule/ClipboardSchedule.module.scss
+++ b/apps/site/src/views/Schedule/sections/ClipboardSchedule/ClipboardSchedule.module.scss
@@ -35,10 +35,6 @@
 	border-bottom: 2px solid theme.$light-blue;
 }
 
-.date {
-	margin-top: 36px;
-}
-
 .eventTitle {
 	font-size: 24px;
 }

--- a/apps/site/src/views/Schedule/sections/ClipboardSchedule/ClipboardSchedule.tsx
+++ b/apps/site/src/views/Schedule/sections/ClipboardSchedule/ClipboardSchedule.tsx
@@ -27,21 +27,32 @@ const dateTimeFormat = new Intl.DateTimeFormat("en", {
 	minute: "numeric",
 });
 
+const WEEKDAYS = [
+	"Sunday",
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+];
+
 function ClipboardSchedule({ schedule }: ClipboardScheduleProps) {
 	return (
 		<Container
 			as="section"
-			className={styles.clipboard + " px-0 position-relative"}
+			className={styles.clipboard + " px-0 pt-5 position-relative"}
 		>
 			<div className={styles.clip}>
 				<Image src={clip} alt="Clipboard clip" className={styles.clip} />
 			</div>
 			<Accordion defaultActiveKey="0" className={styles.accordion}>
 				{schedule.map((day, i) => (
-					<div key={i}>
-						<h2 className={styles.date}>
+					<div className="mt-5" key={i}>
+						<h2>{WEEKDAYS[day[0].startTime.getDay()]}</h2>
+						<h3 className="text-center mb-5">
 							{day[0].startTime.toLocaleDateString()}
-						</h2>
+						</h3>
 						{day.map(
 							({ title, description, location, hosts, startTime, endTime }) => (
 								<Accordion.Item

--- a/apps/site/src/views/Schedule/sections/ClipboardSchedule/ClipboardSchedule.tsx
+++ b/apps/site/src/views/Schedule/sections/ClipboardSchedule/ClipboardSchedule.tsx
@@ -27,15 +27,9 @@ const dateTimeFormat = new Intl.DateTimeFormat("en", {
 	minute: "numeric",
 });
 
-const WEEKDAYS = [
-	"Sunday",
-	"Monday",
-	"Tuesday",
-	"Wednesday",
-	"Thursday",
-	"Friday",
-	"Saturday",
-];
+const weekdayFormat = new Intl.DateTimeFormat("en", {
+	weekday: "long",
+});
 
 function ClipboardSchedule({ schedule }: ClipboardScheduleProps) {
 	return (
@@ -49,7 +43,7 @@ function ClipboardSchedule({ schedule }: ClipboardScheduleProps) {
 			<Accordion defaultActiveKey="0" className={styles.accordion}>
 				{schedule.map((day, i) => (
 					<div className="mt-5" key={i}>
-						<h2>{WEEKDAYS[day[0].startTime.getDay()]}</h2>
+						<h2>{weekdayFormat.format(day[0].startTime)}</h2>
 						<h3 className="text-center mb-5">
 							{day[0].startTime.toLocaleDateString()}
 						</h3>

--- a/apps/site/src/views/Schedule/sections/ClipboardSchedule/ClipboardSchedule.tsx
+++ b/apps/site/src/views/Schedule/sections/ClipboardSchedule/ClipboardSchedule.tsx
@@ -27,6 +27,11 @@ const dateTimeFormat = new Intl.DateTimeFormat("en", {
 	minute: "numeric",
 });
 
+const monthDayFormat = new Intl.DateTimeFormat("en", {
+	month: "long",
+	day: "numeric",
+});
+
 const weekdayFormat = new Intl.DateTimeFormat("en", {
 	weekday: "long",
 });
@@ -44,9 +49,9 @@ function ClipboardSchedule({ schedule }: ClipboardScheduleProps) {
 				{schedule.map((day, i) => (
 					<div className="mt-5" key={i}>
 						<h2>{weekdayFormat.format(day[0].startTime)}</h2>
-						<h3 className="text-center mb-5">
-							{day[0].startTime.toLocaleDateString()}
-						</h3>
+						<p className="text-center mb-5 h3">
+							{monthDayFormat.format(day[0].startTime)}
+						</p>
 						{day.map(
 							({ title, description, location, hosts, startTime, endTime }) => (
 								<Accordion.Item
@@ -54,8 +59,10 @@ function ClipboardSchedule({ schedule }: ClipboardScheduleProps) {
 									eventKey={title}
 									className={styles.accordionItem}
 								>
-									<Accordion.Header className={styles.accordionHeader}>
-										<h3 className={styles.eventTitle}>{title}</h3>
+									<Accordion.Header as="h3" className={styles.accordionHeader}>
+										<span className={styles.eventTitle + " h3 mb-0"}>
+											{title}
+										</span>
 										{/* <span>{hosts?.join()}</span> */}
 										<span className="text-end ms-auto">
 											{location},{" "}


### PR DESCRIPTION
Called the `getDay` function on the start time to get the 0-indexed day of the week and used that value to index a hardcoded array of days of the week.