### PR TITLE
Restore resources link in navbar

### DIFF
--- a/apps/site/src/components/NavBar/NavBar.tsx
+++ b/apps/site/src/components/NavBar/NavBar.tsx
@@ -31,7 +31,7 @@ export default function NavBar() {
 							>
 								Home
 							</Link>
-							{/* <Link
+							<Link
 								href="/resources"
 								className={
 									activeRoute === "/resources"
@@ -40,7 +40,7 @@ export default function NavBar() {
 								}
 							>
 								Resources
-							</Link> */}
+							</Link>
 							<Link
 								href="/schedule"
 								className={


### PR DESCRIPTION
Before releasing the resources and schedule pages, we should also restore the link to the resources page in the navbar.