### PR TITLE
fix: backend resources grid issue

### DIFF
--- a/apps/site/src/views/Resources/sections/BackendResources/BackendResources.tsx
+++ b/apps/site/src/views/Resources/sections/BackendResources/BackendResources.tsx
@@ -24,7 +24,7 @@ async function BackendResources() {
 				{/* Sticky Notes */}
 				{resources.map(
 					({ _id, title, description, link, logo, stickyNoteColor }) => (
-						<div className={styles.column + " div"} key={_id}>
+						<div className={styles.column + " col"} key={_id}>
 							<ResourceCard
 								title={title}
 								description={<PortableText value={description} />}


### PR DESCRIPTION
The wrong class name was used when setting up the grid layout for the backend resources section. This PR changes it to the correct name.